### PR TITLE
feat: añadir contador de botes en raquetas

### DIFF
--- a/mongpong/index.html
+++ b/mongpong/index.html
@@ -15,6 +15,11 @@
       <span class="dash">—</span>
       <span id="scoreR">0</span>
     </div>
+    <div class="bounces">
+      Botes: <span id="bounceL">0</span>
+      <span class="dash">—</span>
+      <span id="bounceR">0</span>
+    </div>
     <div class="controls">
   <strong>Controles</strong> · P1: W/S · P2: ↑/↓ ·
   <kbd>P</kbd> Pausa · <kbd>R</kbd> Reiniciar · <kbd>A</kbd> IA P2

--- a/mongpong/main.js
+++ b/mongpong/main.js
@@ -4,6 +4,8 @@ const ctx = canvas.getContext('2d', { alpha: false });
 
 const scoreL = document.getElementById('scoreL');
 const scoreR = document.getElementById('scoreR');
+const bounceL = document.getElementById('bounceL');
+const bounceR = document.getElementById('bounceR');
 const statusEl = document.getElementById('status');
 
 const modsBtn = document.getElementById('modsBtn');
@@ -17,8 +19,8 @@ const STATE = {
   paused: false,
   aiRight: true,
   targetScore: 7,
-  left: { y: 0, vy: 0, score: 0 },
-  right:{ y: 0, vy: 0, score: 0 },
+  left: { y: 0, vy: 0, score: 0, bounces: 0 },
+  right:{ y: 0, vy: 0, score: 0, bounces: 0 },
   balls: [], // ahora soporta varias pelotas
   keys: { w:false, s:false, up:false, down:false },
   t0: performance.now(),
@@ -212,6 +214,10 @@ function collideWithPaddle(b, side, padY) {
   if (side === 'left') b.x = PAD.margin + PAD.w + b.r + 0.1;
   else b.x = STATE.w - PAD.margin - PAD.w - b.r - 0.1;
 
+  if (side === 'left') STATE.left.bounces++;
+  else STATE.right.bounces++;
+  updateBounceboard();
+
   onBounce(b);
   blip(340);
 }
@@ -254,6 +260,11 @@ function resetBallInstance(b, dirX = 1) {
 function updateScoreboard() {
   scoreL.textContent = STATE.left.score;
   scoreR.textContent = STATE.right.score;
+}
+
+function updateBounceboard() {
+  bounceL.textContent = STATE.left.bounces;
+  bounceR.textContent = STATE.right.bounces;
 }
 
 function checkWin() {
@@ -319,6 +330,7 @@ window.addEventListener('keydown', (e) => {
   }
   if (e.key === 'r' || e.key === 'R') {
     STATE.left.score = 0; STATE.right.score = 0; updateScoreboard();
+    STATE.left.bounces = 0; STATE.right.bounces = 0; updateBounceboard();
     STATE.paused = false; statusEl.textContent = '';
     centerEntities();
   }
@@ -335,4 +347,6 @@ window.addEventListener('resize', resize);
 
 // Init
 resize();
+updateScoreboard();
+updateBounceboard();
 requestAnimationFrame(loop);

--- a/mongpong/style.css
+++ b/mongpong/style.css
@@ -31,6 +31,11 @@ kbd {
 }
 .dash { margin: 0 10px; opacity: .7; }
 
+.bounces {
+  font-weight: 600; letter-spacing: .04em; font-size: 18px;
+  margin-top: 4px;
+}
+
 .btn {
   background: #121a2b; border: 1px solid #2a3652; padding: 4px 10px; border-radius: 8px;
   color: #eaf2ff; cursor: pointer; font: inherit;


### PR DESCRIPTION
## Summary
- muestra contador de botes para cada jugador
- estiliza nuevo marcador de botes
- reinicia los botes con la tecla R

## Testing
- `npm test` *(falla: missing script test)*

------
https://chatgpt.com/codex/tasks/task_e_68bdaeed207083208621a839ef724376